### PR TITLE
Fix duplicated parser switch cases

### DIFF
--- a/CwlDemangle/CwlDemangle.swift
+++ b/CwlDemangle/CwlDemangle.swift
@@ -1606,7 +1606,7 @@ fileprivate extension Demangler {
 		case "s": return SwiftSymbol(kind: .outlinedRelease, child: try require(pop(kind: .type)))
 		case "b": return SwiftSymbol(kind: .outlinedInitializeWithTake, child: try require(pop(kind: .type)))
 		case "c": return SwiftSymbol(kind: .outlinedInitializeWithCopy, child: try require(pop(kind: .type)))
-		case "f": return SwiftSymbol(kind: .outlinedAssignWithTake, child: try require(pop(kind: .type)))
+		case "d": return SwiftSymbol(kind: .outlinedAssignWithTake, child: try require(pop(kind: .type)))
 		case "f": return SwiftSymbol(kind: .outlinedAssignWithCopy, child: try require(pop(kind: .type)))
 		default: throw failure
 		}
@@ -1851,7 +1851,7 @@ fileprivate extension Demangler {
 			case "E", "M":
 				size = try demangleIndexAsName()
 				alignment = try demangleIndexAsName()
-			case "e", "E":
+			case "e", "m":
 				size = try demangleIndexAsName()
 			default: throw failure
 			}
@@ -2301,7 +2301,6 @@ fileprivate extension Demangler {
 		case "I": fallthrough
 		case "v": fallthrough
 		case "P": fallthrough
-		case "s": fallthrough
 		case "Z": fallthrough
 		case "C": fallthrough
 		case "V": fallthrough


### PR DESCRIPTION
This PR audits a few parser switch cases which compiler has highlighted as being duplicate. These include:

- `f` case in `demangleWitness` was duplicated as `outlinedAssignWithTake` and `outlinedAssignWithCopy`. `Demangler.cpp` shows that `f` case should correspond to `outlinedAssignWithCopy`, while `outlinedAssignWithTake` should actually be a `d` case (which was missing).
- `E` case in `demangleGenericRequirement` constraint layout requirement was duplicated as "size + alignment" and "size only". `Demangler.cpp` shows that it's the `m` case (which was missing) that should be "size only", while `E` should be "size + alignment".
- `s` case in `demangleSwift3Context` was duplicated as "StdLib module" and "entity" (via fallthrough). I'm not sure about this one, so I've removed the fallthrough case to match current behaviour.

Unit tests still pass of course. Please note that I haven't gone through the changes in `Demangler.cpp` since Nov 2017 – this only covers the issues that compiler has warned about.