### PR TITLE
Fix forced unwrapped optional causing parse crash

### DIFF
--- a/CwlDemangle/CwlDemangle.swift
+++ b/CwlDemangle/CwlDemangle.swift
@@ -3123,8 +3123,9 @@ fileprivate func decodeSwiftPunycode(_ value: String) -> String {
 		bias = k
 		n = n + i / (output.count + 1)
 		i = i % (output.count + 1)
-		output.insert(UnicodeScalar(n)!, at: i)
-		i += 1
+        let validScalar = UnicodeScalar(n) ?? UnicodeScalar(".")!
+        output.insert(validScalar, at: i)
+        i += 1
 	}
 	return String(output.map { Character($0) })
 }

--- a/CwlDemangleTests/CwlDemangleTests.swift
+++ b/CwlDemangleTests/CwlDemangleTests.swift
@@ -3213,6 +3213,18 @@ class CwlDemangleTests: XCTestCase {
 			XCTFail("Failed to demangle \(input). Got \(error), expected \(output)")
 		}
 	}
+    
+    func test_T011CryptoSwift3AESC0017sBoxstorage_wEEFc33_2FA9B7ACC72B80C564A140F8079C9914LLSays6UInt32VGSgvpWvd() {
+        let input = "_T011CryptoSwift3AESC0017sBoxstorage_wEEFc33_2FA9B7ACC72B80C564A140F8079C9914LLSays6UInt32VGSgvpWvd"
+        let output = "direct field offset for CryptoSwift.AES.(sBox.storage in _2FA9B7ACC72B80C564A140F8079C9914) : [Swift.UInt32]?"
+        do {
+            let parsed = try parseMangledSwiftSymbol(input)
+            let result = parsed.print(using: SymbolPrintOptions.default.union(.synthesizeSugarOnTypes))
+            XCTAssert(result == output, "Failed to demangle \(input). Got \(result), expected \(output)")
+        } catch {
+            XCTFail("Failed to demangle \(input). Got \(error), expected \(output)")
+        }
+    }
 	func test_T0LiteralAByxGxd_tcfC() {
 		let input = "_T0LiteralAByxGxd_tcfC"
 		do {


### PR DESCRIPTION
When using the software I noticed it was crashing when trying to parse this mangled name `_T011CryptoSwift3AESC0017sBoxstorage_wEEFc33_2FA9B7ACC72B80C564A140F8079C9914LLSays6UInt32VGSgvpWvd`. 
The crash was due to a force unwrapped optional that was returning `nil`.
Fixed the crash and added a test for this case using the output of `xcrun swift-demangle _T011CryptoSwift3AESC0017sBoxstorage_wEEFc33_2FA9B7ACC72B80C564A140F8079C9914LLSays6UInt32VGSgvpWvd` as the expected output.